### PR TITLE
condition the use of C++ features on support of those features

### DIFF
--- a/include/bronto/bronto.hpp
+++ b/include/bronto/bronto.hpp
@@ -151,16 +151,16 @@
 "  See https://brontosource.dev/docs for more documentation.\n\n"
 // clang-format on
 
-#if __cpp_static_assert >= 200410L
-#define BRONTO_INTERNAL_USAGE_FAIL(tag)                                        \
-  BrontoInternalIgnoreStruct;                                                  \
-  static_assert(false, BRONTO_INTERNAL_USAGE_FAIL_MESSAGE(tag));               \
-  struct
-#elif __clang__ || __GNUC__
+#if __clang__ || __GNUC__
 #define BRONTO_INTERNAL_USAGE_FAIL(tag)                                        \
   BrontoInternalIgnoreStruct;                                                  \
   _Pragma(BRONTO_INTERNAL_STRINGIFY(                                           \
       GCC error BRONTO_INTERNAL_USAGE_FAIL_MESSAGE(tag))) struct
+#elif __cpp_static_assert >= 200410L
+#define BRONTO_INTERNAL_USAGE_FAIL(tag)                                        \
+  BrontoInternalIgnoreStruct;                                                  \
+  static_assert(false, BRONTO_INTERNAL_USAGE_FAIL_MESSAGE(tag));               \
+  struct
 #endif
 
 #ifdef BRONTO_REFACTOR

--- a/include/bronto/bronto.hpp
+++ b/include/bronto/bronto.hpp
@@ -145,14 +145,23 @@
 #define BRONTO_INTERNAL_USAGE_KIND_forbidden() BRONTO_INTERNAL_ACCEPTABLE_USAGE
 
 // clang-format off
-#define BRONTO_INTERNAL_USAGE_FAIL(tag) \
-    BrontoInternalIgnoreStruct; static_assert(false, R"(
-  The tag ")" BRONTO_INTERNAL_STRINGIFY(tag) R"(" is not supported inside the BRONTO_USAGE macro.
-  Only "required", "allowed", and "forbidden" are supported.
-  See https://brontosource.dev/docs for more documentation.
-
-)"); struct
+#define BRONTO_INTERNAL_USAGE_FAIL_MESSAGE(tag) "\n" \
+"  The tag \"" BRONTO_INTERNAL_STRINGIFY(tag) "\" is not supported inside the BRONTO_USAGE macro.\n" \
+"  Only \"required\", \"allowed\", and \"forbidden\" are supported.\n" \
+"  See https://brontosource.dev/docs for more documentation.\n\n"
 // clang-format on
+
+#if __cpp_static_assert >= 200410L
+#define BRONTO_INTERNAL_USAGE_FAIL(tag)                                        \
+  BrontoInternalIgnoreStruct;                                                  \
+  static_assert(false, BRONTO_INTERNAL_USAGE_FAIL_MESSAGE(tag));               \
+  struct
+#elif __clang__ || __GNUC__
+#define BRONTO_INTERNAL_USAGE_FAIL(tag)                                        \
+  BrontoInternalIgnoreStruct;                                                  \
+  _Pragma(BRONTO_INTERNAL_STRINGIFY(                                           \
+      GCC error BRONTO_INTERNAL_USAGE_FAIL_MESSAGE(tag))) struct
+#endif
 
 #ifdef BRONTO_REFACTOR
 #define BRONTO_INTERNAL_USAGE(tag)                                             \
@@ -172,6 +181,7 @@
 
 #endif
 
+#ifdef __cplusplus
 namespace bronto {
 
 // `bronto::rewrite_decl`:
@@ -201,8 +211,8 @@ struct rewrite_expr {};
 // https://brontosource.dev/docs for more details.
 struct rewrite_param {};
 
-
 }  // namespace bronto
+#endif  // __cplusplus
 
 // `BRONTO_REFACTOR`:
 //

--- a/tests/bronto/BUILD.bazel
+++ b/tests/bronto/BUILD.bazel
@@ -5,3 +5,9 @@ cc_test(
     srcs = ["compilation.test.cpp"],
     deps = ["//:bronto"],
 )
+
+cc_test(
+    name = "c_compilation_test",
+    srcs = ["compilation.test.c"],
+    deps = ["//:bronto"],
+)

--- a/tests/bronto/compilation.test.c
+++ b/tests/bronto/compilation.test.c
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: 0BSD
+
+#include <bronto/bronto.hpp>
+
+BRONTO_INLINE()
+void f() {}
+
+#if BRONTO_REFACTOR
+#error This should never be executed because `BRONTO_REFACTOR` is not defined during compilation, only during the tool execution.
+#endif
+
+int main() { return 0; }


### PR DESCRIPTION
Pragma-based error message:
```
tests/bronto/compilation.test.cpp:19:10: error:
  The tag "invalid" is not supported inside the BRONTO_USAGE macro.
  Only "required", "allowed", and "forbidden" are supported.
  See https://brontosource.dev/docs for more documentation.


   19 |   struct BRONTO_USAGE(invalid) Invalid : bronto::rewrite_expr {};
      |          ^
bazel-out/darwin_arm64-opt/bin/_virtual_includes/bronto/bronto/bronto.hpp:131:3: note: expanded from macro 'BRONTO_USAGE'
  131 |   BRONTO_INTERNAL_VALIDATE_USAGE(BRONTO_INTERNAL_CAT(                          \
      |   ^
bazel-out/darwin_arm64-opt/bin/_virtual_includes/bronto/bronto/bronto.hpp:136:35: note: expanded from macro 'BRONTO_INTERNAL_VALIDATE_USAGE'
  136 |                                   BRONTO_INTERNAL_USAGE_FAIL)
      |                                   ^
```

`static_assert` based error message:
```
tests/bronto/compilation.test.cpp:19:10: error: static assertion failed:
  The tag "invalid" is not supported inside the BRONTO_USAGE macro.
  Only "required", "allowed", and "forbidden" are supported.
  See https://brontosource.dev/docs for more documentation.


   19 |   struct BRONTO_USAGE(invalid) Invalid : bronto::rewrite_expr {};
      |          ^~~~~~~~~~~~~~~~~~~~~
bazel-out/darwin_arm64-opt/bin/_virtual_includes/bronto/bronto/bronto.hpp:131:3: note: expanded from macro 'BRONTO_USAGE'
  131 |   BRONTO_INTERNAL_VALIDATE_USAGE(BRONTO_INTERNAL_CAT(                          \
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  132 |       BRONTO_INTERNAL_USAGE_KIND_, tag)())(tag) BRONTO_INTERNAL_USAGE(tag)
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
bazel-out/darwin_arm64-opt/bin/_virtual_includes/bronto/bronto/bronto.hpp:136:35: note: expanded from macro 'BRONTO_INTERNAL_VALIDATE_USAGE'
  136 |                                   BRONTO_INTERNAL_USAGE_FAIL)
      |                                   ^
bazel-out/darwin_arm64-opt/bin/_virtual_includes/bronto/bronto/bronto.hpp:138:38: note: expanded from macro 'BRONTO_INTERNAL_VALIDATE_USAGE_'
  138 |   BRONTO_INTERNAL_VALIDATE_USAGE_GET(__VA_ARGS__)
      |                                      ^
bazel-out/darwin_arm64-opt/bin/_virtual_includes/bronto/bronto/bronto.hpp:139:64: note: expanded from macro 'BRONTO_INTERNAL_VALIDATE_USAGE_GET'
  139 | #define BRONTO_INTERNAL_VALIDATE_USAGE_GET(arg0, arg1, N, ...) N
      |                                                                ^
bazel-out/darwin_arm64-opt/bin/_virtual_includes/bronto/bronto/bronto.hpp:157:17: note: expanded from macro 'BRONTO_INTERNAL_USAGE_FAIL'
  157 |   static_assert(false, BRONTO_INTERNAL_USAGE_FAIL_MESSAGE(tag));               \
      |                 ^~~~~
```

This also assumes that the present of the un-expanded `BRONTO_INTERNAL_USAGE_FAIL(tag)` will itself trigger a failure if the other explicit message syntaxes aren't supported.