### PR TITLE
 Add a `bronto::rewrite_type` tag.

### DIFF
--- a/include/bronto/bronto.hpp
+++ b/include/bronto/bronto.hpp
@@ -255,6 +255,15 @@ struct rewrite_expr {};
 // https://brontosource.dev/docs for more details.
 struct rewrite_param {};
 
+// `bronto::rewrite_type`:
+//
+// An empty struct used as a marker that any struct/class inheriting from it
+// represents a type replacement. Member aliases and alias templates can be
+// annotated as `BRONTO_BEFORE` to indicate they represent a pattern to be
+// searched for, or `BRONTO_AFTER` to indicate they represent a replacement
+// pattern. See https://brontosource.dev/docs for more details.
+struct rewrite_type {};
+
 // `bronto::avoid_adl`:
 //
 // An empty class that can be inherited from to bring in other namespaces for

--- a/tests/bronto/compilation.test.cpp
+++ b/tests/bronto/compilation.test.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: 0BSD
 
 #include <bronto/bronto.hpp>
+#include <cstdint>
 
 BRONTO_INLINE()
 void f() {}
@@ -12,7 +13,7 @@ using Old BRONTO_INLINE() = New;
 #error This should never be executed because `BRONTO_REFACTOR` is not defined during compilation, only during the tool execution.
 #endif
 
-struct Rule : bronto::rewrite_decl {
+struct DeclRule : bronto::rewrite_decl {
   struct BRONTO_USAGE(required) Required : bronto::rewrite_expr {};
   struct BRONTO_USAGE(allowed) Allowed : bronto::rewrite_expr {};
   struct BRONTO_USAGE(forbidden) Forbidden : bronto::rewrite_expr {};
@@ -40,6 +41,11 @@ struct RuleLoose : bronto::rewrite_decl {
 
   BRONTO_AFTER("loose")
   void after() { int var; }
+};
+
+struct TypeRule : bronto::rewrite_type {
+  using before BRONTO_BEFORE() = std::int32_t;
+  using after BRONTO_AFTER()   = std::int64_t;
 };
 
 int main() { return 0; }


### PR DESCRIPTION
 Add a `bronto::rewrite_type` tag directing `bronto-refactor` to replaces matches of a type with the corresponding replacement.